### PR TITLE
Fix scaling blur

### DIFF
--- a/src/cljs/hawkthorne/core.cljs
+++ b/src/cljs/hawkthorne/core.cljs
@@ -9,9 +9,8 @@
             ;the first parameter is the tileset name as specified in Tiled, the second is the key to the asset
             (.. this -map (addTilesetImage "greendale-interior" "greendale-interior"))
 
-            (set! (.. this -background) (.. this -map (createLayer "background")))
-            (set! (.. this -accents) (.. this -map (createLayer "accents")))
-            (set! (.. this -floor) (.. this -map (createLayer "floor")))
+            (doseq [x ["background" "accents" "floor"]]
+              (aset this x (.. this -map (createLayer x))))
 
             (.. this -map (setCollisionBetween 15 15 true "floor"))
 

--- a/src/cljs/hawkthorne/core.cljs
+++ b/src/cljs/hawkthorne/core.cljs
@@ -55,6 +55,9 @@
                                           (clj->js {:font "16px Arial"
                                                     :fill "#ffffff"})))
 
+            ;Prevent aliasing when scaling
+            (.setImageRenderingCrisp js/Phaser.Canvas (.. game -canvas))
+
             (set! (.. this -fpsText -fixedToCamera) true))
 
     (preload [this]


### PR DESCRIPTION
Use Phaser.Canvas.setImageRenderingCrisp to prevent aliasing when the game is scaled up.

Add a doseq block with aset for setting map layers.